### PR TITLE
feat: Update Android build configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 
-android {namespace 'corp.blayzer.randomit'  // Replace with your app's namespace
+android {
+    namespace 'corp.blayzer.randomit'  // Replace with your app's namespace
     compileSdk  34
     defaultConfig {
         applicationId "corp.blayzer.randomit"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,15 +1,14 @@
 apply plugin: 'com.android.application'
 
-android {
-    namespace 'corp.blayzer.randomit'  // Replace with your app's namespace
+android {namespace 'corp.blayzer.randomit'  // Replace with your app's namespace
     compileSdk  34
     defaultConfig {
         applicationId "corp.blayzer.randomit"
         minSdk  21
-        targetSdk  34
-        versionName '3.0'
+        targetSdk  35
+        versionName '3.2'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
-        versionCode 6
+        versionCode 10
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,35 +1,44 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    namespace 'corp.blayzer.randomit'  // Replace with your app's namespace
-    compileSdk  34
+    namespace 'corp.blayzer.randomit'
+    compileSdk 36
+
     defaultConfig {
         applicationId "corp.blayzer.randomit"
-        minSdk  21
-        targetSdk  35
+        minSdk 21
+        targetSdk 35
+        versionCode 11
         versionName '3.2'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
-        versionCode 10
     }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    // The productFlavors block can be removed if you are not using it.
     productFlavors {
     }
 }
 
 dependencies {
-    implementation fileTree(include: ['*.jar'], dir: 'libs')
-    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
-    implementation 'androidx.appcompat:appcompat:1.7.0'
+    // Keep only the latest versions of your dependencies
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'androidx.browser:browser:1.9.0'
+    implementation 'com.google.android.material:material:1.13.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation 'androidx.browser:browser:1.0.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+
+    // Testing dependencies
     testImplementation 'junit:junit:4.12'
-    implementation 'com.google.android.material:material:1.12.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.6.1') { // Updated version
+        // This exclusion is generally no longer needed with modern androidx libraries
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()  // Replace jcenter() with mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:8.2.2" // Latest stable version
+        classpath 'com.android.tools.build:gradle:8.12.0' // Latest stable version
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updates the app's build configuration in `app/build.gradle`.

Key changes include:
- Bumps `targetSdk` from 34 to 35.
- Increments `versionName` from '3.0' to '3.2'.
- Increases `versionCode` from 6 to 10.